### PR TITLE
Fixing typo

### DIFF
--- a/docs/src/lecture_03/lecture.md
+++ b/docs/src/lecture_03/lecture.md
@@ -103,7 +103,7 @@ But fields are still accessible:
 ```julia
 grass.size = 10000
 ```
-Recall that ```grass.size=1000``` is a syntax of ```setproperty!(grass,:size,1000), which can be redefined:
+Recall that ```grass.size=1000``` is a syntax of ```setproperty!(grass,:size,1000)```, which can be redefined:
 ```julia
 function Base.setproperty!(obj::Grass, sym::Symbol, val)
     if sym==:size


### PR DESCRIPTION
Missing ticks around an inline occurrence of `setproperty!`.